### PR TITLE
fix: Don't attempt to remove an unmapped file.

### DIFF
--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -21,7 +21,7 @@ var DependencyResolver = function() {
 
   var resolveFile = function(filepath, files, alreadyResolvedMap) {
     if (!fileMap[filepath]) {
-      // console.log('IGORED', filepath);
+      // console.log('IGNORED', filepath);
       files.push(filepath);
       return;
     }
@@ -41,7 +41,11 @@ var DependencyResolver = function() {
   };
 
   this.removeFile = function(filepath) {
-    // TODO(vojta): handle if unknown file
+    if (!fileMap[filepath]) {
+      // console.log('Cannot remove unmapped file', filepath);
+      return;
+    }
+
     fileMap[filepath].provides.forEach(function(dep) {
       if (provideMap[dep] === filepath) {
         provideMap[dep] = null;


### PR DESCRIPTION
Quite frequently, I'm seeing `fileMap[filepath]` be undefined in `DependencyResolver.removeFile()`. I run this in IntelliJ and it seems to happen when I'm saving quite frequently.

I'm not really sure what the root cause is here, so this is a bit of a bandaid. When using IntelliJ I see it trying to remove files such as /Users/rob/.../tests/integration/TrackingIntegrationTests.js___jb_old___ even though I've configured just to map *.js.
