### PR TITLE
Add an error message for missing dependencies.

### DIFF
--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -2,7 +2,9 @@
 var goog = require('./goog');
 
 // TODO(vojta): can we handle provide "same thing provided multiple times" ?
-var DependencyResolver = function() {
+var DependencyResolver = function(logger) {
+  var log = logger.create('closure');
+
   // the state
   var fileMap = Object.create(null);
   var provideMap = Object.create(null);
@@ -29,8 +31,13 @@ var DependencyResolver = function() {
     // resolve all dependencies first
     fileMap[filepath].requires.forEach(function(dep) {
       if (!alreadyResolvedMap[dep]) {
-        // TODO(vojta): error if dep not provided
-        resolveFile(provideMap[dep], files, alreadyResolvedMap);
+        if (provideMap[dep]) {
+          resolveFile(provideMap[dep], files, alreadyResolvedMap);
+        } else {
+          log.error('MISSING DEPENDENCY:', dep);
+          log.error('Did you forget to preprocess your source directory? Or did you leave off ' +
+                      'the google closure library deps.js file?');
+        }
       }
     });
 

--- a/test/resolver.spec.coffee
+++ b/test/resolver.spec.coffee
@@ -1,4 +1,12 @@
 # expect = require('chai').expect
 # DependencyResolver = require '../lib/resolver'
-
+# 
 # describe 'DependencyResolver', ->
+#   resolver = {}
+#   logger = {}
+# 
+#   beforeEach ->
+#     logger = { create: (x) -> { error: () -> } }
+#     resolver = new DependencyResolver(logger)
+#   
+#   it 'should have tests', ->


### PR DESCRIPTION
This ensures that something is printed out for users who didn't add a mapping for one of their dependencies. Either they missed a deps.js file or they didn't preprocess all of their source files. The current behavior adds an undefined filepath which ends up causing the karma web-server to blow up when it trys to do indexOf on undefined.

I'm sure it would be better to actually get the real karma logger here, but I didn't see any examples of doing that in any of the other plugins. So for now I'm just using a console.error.
