### PR TITLE
Fixes the closure deps resolver.

### DIFF
--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -6,8 +6,8 @@ var DependencyResolver = function(logger) {
   var log = logger.create('closure');
 
   // the state
-  var fileMap = Object.create(null);
-  var provideMap = Object.create(null);
+  var fileMap = Object.create({});
+  var provideMap = Object.create({});
 
   var updateProvideMap = function(filepath, oldProvides, newProvides) {
     oldProvides.forEach(function(dep) {


### PR DESCRIPTION
While resolving closure deps.

we are assigning the fileMap and provideMap to __proto__ in which binding to proto object is broken because of creating the object using Object.create(null)