### PR TITLE
rm spec issues re Object.create(null) & __proto__

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,29 @@
+{
+    "globalstrict": true,
+    "latedef": true,
+    "asi": false,
+    "boss": false,
+    "eqeqeq": true,
+    "eqnull": true,
+    "evil": false,
+    "multistr": false,
+    "freeze": true,
+    "newcap": true,
+    "indent": 4,
+    "curly": true,
+    "trailing": true,
+    "immed": true,
+    "nonbsp": true,
+    "bitwise": true,
+    "noarg": true,
+    "noempty": true,
+    "undef": true,
+    "unused": true,
+    "strict": false,
+    "sub": true,
+    "maxparams": 5,
+    "predef": [
+        "require",
+        "module"
+    ]
+}

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -1,38 +1,39 @@
 // var utils = require('./utils');
 var goog = require('./goog');
+var shadow = require('./shadow');
 
 // TODO(vojta): can we handle provide "same thing provided multiple times" ?
 var DependencyResolver = function(logger) {
   var log = logger.create('closure');
 
   // the state
-  var fileMap = Object.create(null);
-  var provideMap = Object.create(null);
+  var fileMap = shadow();
+  var provideMap = shadow();
 
   var updateProvideMap = function(filepath, oldProvides, newProvides) {
     oldProvides.forEach(function(dep) {
-      if (provideMap[dep] === filepath) {
-        provideMap[dep] = null;
+      if (provideMap.get(dep) === filepath) {
+        provideMap.set(dep, null);
       }
     });
 
     newProvides.forEach(function(dep) {
-      provideMap[dep] = filepath;
+      provideMap.set(dep, filepath);
     });
   };
 
   var resolveFile = function(filepath, files, alreadyResolvedMap) {
-    if (!fileMap[filepath]) {
+    if (!fileMap.has(filepath)) {
       // console.log('IGNORED', filepath);
       files.push(filepath);
       return;
     }
 
     // resolve all dependencies first
-    fileMap[filepath].requires.forEach(function(dep) {
-      if (!alreadyResolvedMap[dep]) {
-        if (provideMap[dep]) {
-          resolveFile(provideMap[dep], files, alreadyResolvedMap);
+    fileMap.get(filepath).requires.forEach(function(dep) {
+      if (!alreadyResolvedMap.get(dep)) {
+        if (provideMap.get(dep)) {
+          resolveFile(provideMap.get(dep), files, alreadyResolvedMap);
         } else {
           log.error('MISSING DEPENDENCY:', dep);
           log.error('Did you forget to preprocess your source directory? Or did you leave off ' +
@@ -42,33 +43,33 @@ var DependencyResolver = function(logger) {
     });
 
     files.push(filepath);
-    fileMap[filepath].provides.forEach(function(dep) {
-      alreadyResolvedMap[dep] = true;
+    fileMap.get(filepath).provides.forEach(function(dep) {
+      alreadyResolvedMap.set(dep, true);
     });
   };
 
   this.removeFile = function(filepath) {
-    if (!fileMap[filepath]) {
+    if (!fileMap.has(filepath)) {
       // console.log('Cannot remove unmapped file', filepath);
       return;
     }
 
-    fileMap[filepath].provides.forEach(function(dep) {
-      if (provideMap[dep] === filepath) {
-        provideMap[dep] = null;
+    fileMap.get(filepath).provides.forEach(function(dep) {
+      if (provideMap.get(dep) === filepath) {
+        provideMap.set(dep, null);
       }
     });
-    fileMap[filepath] = null;
+    fileMap.set(filepath, null);
   };
 
   this.updateFile = function(filepath, content) {
     var parsed = goog.parseProvideRequire(content);
 
-    if (!fileMap[filepath]) {
+    if (!fileMap.has(filepath)) {
       // console.log('New file', filepath, 'adding to the map.');
       // console.log(parsed);
       updateProvideMap(filepath, [], parsed.provides);
-      fileMap[filepath] = parsed;
+      fileMap.set(filepath, parsed);
       return;
     }
 
@@ -91,8 +92,8 @@ var DependencyResolver = function(logger) {
     //   console.log('No requires change in', filepath);
     // }
 
-    updateProvideMap(filepath, fileMap[filepath].provides, parsed.provides);
-    fileMap[filepath] = parsed;
+    updateProvideMap(filepath, fileMap.get(filepath).provides, parsed.provides);
+    fileMap.set(filepath, parsed);
   };
 
   this.resolveFiles = function(files) {
@@ -100,7 +101,7 @@ var DependencyResolver = function(logger) {
     // console.log(fileMap);
 
     var resolvedFiles = [];
-    var alreadyResolvedMap = Object.create(null);
+    var alreadyResolvedMap = shadow();
 
     files.forEach(function(file) {
       resolveFile(file, resolvedFiles, alreadyResolvedMap);
@@ -113,8 +114,8 @@ var DependencyResolver = function(logger) {
     var parsed = goog.parseDepsJs(filepath, content);
 
     /* jshint camelcase: false, proto: true */
-    fileMap.__proto__ = parsed.fileMap;
-    provideMap.__proto__ = parsed.provideMap;
+    fileMap.add(parsed.fileMap);
+    provideMap.add(parsed.provideMap);
   };
 };
 

--- a/lib/shadow.js
+++ b/lib/shadow.js
@@ -1,0 +1,35 @@
+var shadow = function(initial) {
+  var objs = [initial || Object.create(null)];
+  var set = function(k, v) {
+    objs[0][k] = v;
+  };
+  var rem = function(k) {
+    set(k, undefined);
+  };
+  var get = function(k) {
+    var i, v;
+    for (i=0; i < objs.length; i++) {
+      if (Object.prototype.hasOwnProperty.call(objs[i], k)) {
+        v = objs[i][k];
+        if (v !== undefined) {
+          return v;
+        }
+      }
+    }
+  };
+  var add = function(obj) {
+    return objs.push(obj);
+  };
+  var has = function(k) {
+    return get(k) !== undefined;
+  };
+  return {
+    get: get,
+    set: set,
+    rem: rem,
+    add: add,
+    has: has
+  };
+};
+
+module.exports = shadow;

--- a/package.json
+++ b/package.json
@@ -17,21 +17,21 @@
   "author": "Vojta Jina <vojta.jina@gmail.com>",
   "dependencies": {},
   "devDependencies": {
-    "mocha": "~1.8",
-    "chai": "~1.5",
-    "grunt-npm": "~0.0.2",
-    "grunt": "~0.4.1",
-    "grunt-bump": "~0.0.11",
-    "grunt-coffeelint": "~0.0.6",
-    "grunt-contrib-jshint": "~0.6.0",
-    "grunt-simple-mocha": "~0.4.0",
-    "karma": "~0.9.4",
-    "karma-jasmine": "~0.0.1",
-    "grunt-auto-release": "~0.0.3"
+    "chai": "^3.0.0",
+    "coffeelint": "^1.10.1",
+    "grunt": "^0.4.5",
+    "grunt-auto-release": "0.0.6",
+    "grunt-bump": "^0.3.1",
+    "grunt-coffeelint": "0.0.13",
+    "grunt-contrib-jshint": "^0.11.2",
+    "grunt-npm": "0.0.2",
+    "grunt-simple-mocha": "^0.4.0",
+    "jasmine-core": "^2.3.4",
+    "karma": "^0.12.36",
+    "karma-jasmine": "^0.3.5",
+    "mocha": "^2.2.5"
   },
-  "peerDependencies": {
-    "karma": ">=0.9"
-  },
+  "peerDependencies": {},
   "license": "MIT",
   "contributors": [
     "Rob Barreca <rob.barreca@inmobi.com>",

--- a/test/shadow.spec.coffee
+++ b/test/shadow.spec.coffee
@@ -1,0 +1,105 @@
+expect = require('chai').expect
+shadow = require '../lib/shadow'
+
+describe 'shadow map', ->
+
+  it 'should initialize empty', ->
+    amap = shadow()
+    expect(shadow).to.be.a 'function'
+    expect(amap).to.be.a 'object'
+    expect(amap.get).to.be.a 'function'
+    expect(amap.set).to.be.a 'function'
+    expect(amap.has).to.be.a 'function'
+    expect(amap.add).to.be.a 'function'
+    expect(amap.get('foo')).to.equal undefined
+    expect(amap.get(undefined)).to.equal undefined
+    expect(amap.get(null)).to.equal undefined
+
+  it 'should get and set values properly', ->
+    amap = shadow()
+    expect(amap.get('a')).to.equal undefined
+    expect(amap.has('a')).to.equal false
+    expect(amap.set('a', 'x')).to.equal undefined
+    expect(amap.get('a')).to.equal 'x'
+    expect(amap.has('a')).to.equal true
+
+    expect(amap.set('a', 'y')).to.equal undefined
+    expect(amap.get('a')).to.equal 'y'
+    expect(amap.has('a')).to.equal true
+
+  it 'should handle two objects with second as fallback', ->
+    amap = shadow()
+    expect(amap.set('a', 'x')).to.equal undefined
+
+    expect(amap.get('a')).to.equal 'x'
+    expect(amap.has('a')).to.equal true
+
+    expect(amap.get('b')).to.equal undefined
+    expect(amap.has('b')).to.equal false
+
+    amap.add({ 'a': 'y', 'b': 'z' })
+
+    expect(amap.get('b')).to.equal 'z'
+    expect(amap.has('b')).to.equal true
+
+    expect(amap.get('a')).to.equal 'x'
+    expect(amap.has('a')).to.equal true
+
+    expect(amap.set('b', '0')).to.equal undefined
+    expect(amap.get('b')).to.equal '0'
+    expect(amap.has('b')).to.equal true
+
+  it 'should handle three objects', ->
+    amap = shadow()
+    two = {}
+    three = {}
+    amap.add(two)
+    amap.add(three)
+
+    expect(amap.get('a')).to.equal undefined
+    expect(amap.has('a')).to.equal false
+
+    three.a = 'z'
+    expect(amap.get('a')).to.equal 'z'
+    expect(amap.has('a')).to.equal true
+
+    two.a = 'y'
+    expect(amap.get('a')).to.equal 'y'
+    expect(amap.has('a')).to.equal true
+
+    amap.set('a', 'x')
+    expect(amap.get('a')).to.equal 'x'
+    expect(amap.has('a')).to.equal true
+
+    amap.set('a', undefined)
+    expect(amap.get('a')).to.equal 'y'
+    expect(amap.has('a')).to.equal true
+
+  it 'should handle js wierdness', ->
+    amap = shadow()
+
+    expect(amap.get('__proto__')).to.equal undefined
+    expect(amap.get('toString')).to.equal undefined
+
+    bmap = shadow({})
+    expect(bmap.get('__proto__')).to.equal undefined
+    expect(bmap.get('toString')).to.equal undefined
+
+  it 'should handle removing', ->
+    amap = shadow()
+
+    amap.set('a', 'x')
+    expect(amap.get('a')).to.equal 'x'
+    expect(amap.has('a')).to.equal true
+
+    amap.rem('a')
+    expect(amap.get('a')).to.equal undefined
+    expect(amap.has('a')).to.equal false
+
+    amap.add({'a': 'y'})
+    expect(amap.get('a')).to.equal 'y'
+    expect(amap.has('a')).to.equal true
+
+    amap.set('a', 'x')
+    expect(amap.get('a')).to.equal 'x'
+    expect(amap.has('a')).to.equal true


### PR DESCRIPTION
rm spec issues re Object.create(null) & __proto__

the previous code used the idiom of `Object.create(null)` to use an object like a hash or cache, and leveraged the prototype chain as a type of cache miss failover. there is some js spec weirdness and changes around node 0.12 surrounding the existence of `__proto__` when using `Object.create(null)`.

to eliminate this confusion i've added a function to replace the above so that the semantics are clear and consistent and we aren't using the non-standard `__proto__`.

also update npm dev deps to latest versions and added a missing jshintrc.