### PR TITLE
allowing for whitespace to be inside requires

### DIFF
--- a/lib/goog.js
+++ b/lib/goog.js
@@ -9,12 +9,12 @@ var parseProvideRequire = function(str) {
   var match;
 
   str.split('\n').forEach(function(line) {
-    match = line.match(/^\s*goog\.provide\([\"\'](.*)[\"\']\)/);
+    match = line.match(/^\s*goog\.provide\(\s*[\"\'](.*)[\"\']\s*\)/);
     if (match) {
       provides.push(match[1]);
     }
 
-    match = line.match(/^\s*goog\.require\([\"\'](.*)[\"\']\)/);
+    match = line.match(/^\s*goog\.require\(\s*[\"\'](.*)[\"\']\s*\)/);
     if (match) {
       requires.push(match[1]);
     }

--- a/test-app/js/depA.js
+++ b/test-app/js/depA.js
@@ -1,6 +1,6 @@
-goog.provide('a');
+goog.provide( 'a' );
 
-goog.require('goog.string');
+goog.require( 'goog.string' );
 
 goog.require('b');
 goog.require('c');


### PR DESCRIPTION
I want to have whitespace inside goog.provide/require.
goog.provide( "my.app" );
this pull request fixes it. https://github.com/karma-runner/karma-closure/issues/14.
i updated depA in test-app to have one provide and require have whitespace in it.