### PR TITLE
Fixed deps file loading

### DIFF
--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -113,8 +113,8 @@ var DependencyResolver = function(logger) {
     var parsed = goog.parseDepsJs(filepath, content);
 
     /* jshint camelcase: false, proto: true */
-    fileMap.__proto__ = parsed.fileMap;
-    provideMap.__proto__ = parsed.provideMap;
+    Object.setPrototypeOf(fileMap, parsed.fileMap);
+    Object.setPrototypeOf(provideMap, parsed.provideMap);
   };
 };
 


### PR DESCRIPTION
Replaced __proto__ usage with Object.setPrototypeOf. In some cases, setting __proto__ attribute causes files missing.

Tested in 0.10.30+